### PR TITLE
Add warn mode and ability to log when no rules match

### DIFF
--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -383,6 +383,13 @@ func (c Converter) k8sSelectorToCalico(s *metav1.LabelSelector, selectorType sel
 		selectors = append(selectors, fmt.Sprintf("%s == 'k8s'", apiv3.LabelOrchestrator))
 	}
 
+	// For namespace selectors, if they are present but have no terms, it means "select all
+	// namespaces". We use empty string to represent the nil namespace selector, so use all() to
+	// represent all namespaces.
+	if selectorType == SelectorNamespace && len(s.MatchLabels) == 0 && len(s.MatchExpressions) == 0 {
+		return "all()"
+	}
+
 	// matchLabels is a map key => value, it means match if (label[key] ==
 	// value) for all keys.
 	keys := make([]string, 0, len(s.MatchLabels))

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -383,6 +383,10 @@ func (c Converter) k8sSelectorToCalico(s *metav1.LabelSelector, selectorType sel
 		selectors = append(selectors, fmt.Sprintf("%s == 'k8s'", apiv3.LabelOrchestrator))
 	}
 
+	if s == nil {
+		return strings.Join(selectors, " && ")
+	}
+
 	// For namespace selectors, if they are present but have no terms, it means "select all
 	// namespaces". We use empty string to represent the nil namespace selector, so use all() to
 	// represent all namespaces.
@@ -539,16 +543,6 @@ func (c Converter) k8sPeerToCalicoFields(peer *networkingv1.NetworkPolicyPeer, n
 	}
 	// Peer information available.
 	// Determine the source selector for the rule.
-	// Only one of PodSelector / NamespaceSelector can be defined.
-	if peer.PodSelector != nil {
-		selector = c.k8sSelectorToCalico(peer.PodSelector, SelectorPod)
-		return
-	}
-	if peer.NamespaceSelector != nil {
-		nsSelector = c.k8sSelectorToCalico(peer.NamespaceSelector, SelectorNamespace)
-		selector = fmt.Sprintf("%s == 'k8s'", apiv3.LabelOrchestrator)
-		return
-	}
 	if peer.IPBlock != nil {
 		// Convert the CIDR to include.
 		_, ipNet, err := cnet.ParseCIDR(peer.IPBlock.CIDR)
@@ -568,8 +562,14 @@ func (c Converter) k8sPeerToCalicoFields(peer *networkingv1.NetworkPolicyPeer, n
 			}
 			notNets = append(notNets, ipNet.String())
 		}
+		// If IPBlock is set, then PodSelector and NamespaceSelector cannot be.
 		return
 	}
+
+	// IPBlock is not set to get here.
+	// Note that k8sSelectorToCalico() accepts nil values of the selector.
+	selector = c.k8sSelectorToCalico(peer.PodSelector, SelectorPod)
+	nsSelector = c.k8sSelectorToCalico(peer.NamespaceSelector, SelectorNamespace)
 	return
 }
 

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -58,7 +59,17 @@ func VethNameForWorkload(namespace, podname string) string {
 	// veth name and mac addr.
 	h := sha1.New()
 	h.Write([]byte(fmt.Sprintf("%s.%s", namespace, podname)))
-	return fmt.Sprintf("cali%s", hex.EncodeToString(h.Sum(nil))[:11])
+	prefix := os.Getenv("FELIX_INTERFACEPREFIX")
+	if prefix == "" {
+		// Prefix is not set. Default to "cali"
+		prefix = "cali"
+	} else {
+		// Prefix is set - use the first value in the list.
+		splits := strings.Split(prefix, ",")
+		prefix = splits[0]
+	}
+	log.WithField("prefix", prefix).Debugf("Using prefix to create a WorkloadEndpoint veth name")
+	return fmt.Sprintf("%s%s", prefix, hex.EncodeToString(h.Sum(nil))[:11])
 }
 
 // ParseWorkloadName extracts the Node name, Orchestrator, Pod name and endpoint from the

--- a/lib/backend/k8s/conversion/conversion.go
+++ b/lib/backend/k8s/conversion/conversion.go
@@ -315,6 +315,27 @@ func (c Converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		}
 	}
 
+	dryRun := np.Annotations["projectcalico.org/DryRun"] == "true"
+
+	// The environment variable determines the default, false unless specified
+	logNoRuleMatch := os.Getenv("LOGNORULEMATCH") == "true"
+	switch np.Annotations["projectcalico.org/LogNoRuleMatch"] {
+	case "true":
+		logNoRuleMatch = true
+	case "false":
+		logNoRuleMatch = false
+	}
+
+	if len(ingressRules) > 0 {
+		if logNoRuleMatch || dryRun {
+			ingressRules = append(ingressRules, apiv3.Rule{Action: apiv3.Log})
+		}
+		if dryRun {
+			// Allow all traffic
+			ingressRules = append(ingressRules, apiv3.Rule{Action: apiv3.Allow})
+		}
+	}
+
 	// Generate the egress rules list.
 	var egressRules []apiv3.Rule
 	for _, r := range np.Spec.Egress {
@@ -323,6 +344,15 @@ func (c Converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 			log.WithError(err).Warn("dropping k8s rule that couldn't be converted")
 		} else {
 			egressRules = append(egressRules, rules...)
+		}
+	}
+
+	if len(egressRules) > 0 {
+		if logNoRuleMatch || dryRun {
+			egressRules = append(egressRules, apiv3.Rule{Action: apiv3.Log})
+		}
+		if dryRun {
+			egressRules = append(egressRules, apiv3.Rule{Action: apiv3.Allow})
 		}
 	}
 

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -15,6 +15,8 @@
 package conversion
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -42,6 +44,14 @@ var _ = Describe("Test parsing strings", func() {
 		Expect(weid.Orchestrator).To(Equal("k8s"))
 		Expect(weid.Endpoint).To(Equal("eth0"))
 		Expect(weid.Pod).To(Equal("pod-name"))
+	})
+
+	It("generate a veth name with the right prefix", func() {
+		os.Setenv("FELIX_INTERFACEPREFIX", "eni,veth,foo")
+		defer os.Setenv("FELIX_INTERFACEPREFIX", "")
+
+		name := VethNameForWorkload("namespace", "podname")
+		Expect(name).To(Equal("eni82111e10a96"))
 	})
 
 	It("should parse valid profile names", func() {

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -85,20 +85,20 @@ var _ = Describe("Test parsing strings", func() {
 
 var _ = Describe("Test selector conversion", func() {
 	DescribeTable("selector conversion table",
-		func(inSelector metav1.LabelSelector, selectorType selectorType, expected string) {
+		func(inSelector *metav1.LabelSelector, selectorType selectorType, expected string) {
 			// First, convert the NetworkPolicy using the k8s conversion logic.
 			c := Converter{}
 
-			converted := c.k8sSelectorToCalico(&inSelector, selectorType)
+			converted := c.k8sSelectorToCalico(inSelector, selectorType)
 
 			// Finally, assert the expected result.
 			Expect(converted).To(Equal(expected))
 		},
 
-		Entry("should handle an empty pod selector", metav1.LabelSelector{}, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
-		Entry("should handle an empty namespace selector", metav1.LabelSelector{}, SelectorNamespace, "all()"),
+		Entry("should handle an empty pod selector", &metav1.LabelSelector{}, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
+		Entry("should handle an empty namespace selector", &metav1.LabelSelector{}, SelectorNamespace, "all()"),
 		Entry("should handle an OpDoesNotExist namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpDoesNotExist},
 				},
@@ -107,7 +107,7 @@ var _ = Describe("Test selector conversion", func() {
 			"! has(toast)",
 		),
 		Entry("should handle an OpExists namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpExists},
 				},
@@ -116,7 +116,7 @@ var _ = Describe("Test selector conversion", func() {
 			"has(toast)",
 		),
 		Entry("should handle an OpIn namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpIn, Values: []string{"butter", "jam"}},
 				},
@@ -125,7 +125,7 @@ var _ = Describe("Test selector conversion", func() {
 			"toast in { 'butter', 'jam' }",
 		),
 		Entry("should handle an OpNotIn namespace selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"marmite", "milk"}},
 				},
@@ -134,7 +134,7 @@ var _ = Describe("Test selector conversion", func() {
 			"toast not in { 'marmite', 'milk' }",
 		),
 		Entry("should handle an OpDoesNotExist pod selector",
-			metav1.LabelSelector{
+			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "toast", Operator: metav1.LabelSelectorOpDoesNotExist},
 				},
@@ -142,6 +142,8 @@ var _ = Describe("Test selector conversion", func() {
 			SelectorPod,
 			"projectcalico.org/orchestrator == 'k8s' && ! has(toast)",
 		),
+		Entry("should handle nil pod selector", nil, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
+		Entry("should handle nil namespace selector", nil, SelectorNamespace, ""),
 	)
 })
 
@@ -1081,6 +1083,62 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal("all()"))
+
+		// There should be no Egress rules.
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))
+
+		// Check that Types field exists and has only 'ingress'
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
+	})
+
+	It("should parse a NetworkPolicy with pod and namespace selectors", func() {
+		np := networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"label": "value"},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"namespaceRole": "dev",
+										"namespaceFoo":  "bar",
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"podA": "B",
+										"podC": "D",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			},
+		}
+
+		// Parse the policy.
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert key fields are correct.
+		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.test.policy"))
+
+		// Assert value fields are correct.
+		Expect(int(*pol.Value.(*apiv3.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && podA == 'B' && podC == 'D'"))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal("namespaceFoo == 'bar' && namespaceRole == 'dev'"))
 
 		// There should be no Egress rules.
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))

--- a/lib/backend/k8s/conversion/conversion_test.go
+++ b/lib/backend/k8s/conversion/conversion_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Test selector conversion", func() {
 		},
 
 		Entry("should handle an empty pod selector", metav1.LabelSelector{}, SelectorPod, "projectcalico.org/orchestrator == 'k8s'"),
-		Entry("should handle an empty namespace selector", metav1.LabelSelector{}, SelectorNamespace, ""),
+		Entry("should handle an empty namespace selector", metav1.LabelSelector{}, SelectorNamespace, "all()"),
 		Entry("should handle an OpDoesNotExist namespace selector",
 			metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -997,6 +997,52 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
 	})
 
+	It("should parse a NetworkPolicy with a nil namespace selector", func() {
+		np := networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"label": "value"},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: nil,
+								PodSelector:       &metav1.LabelSelector{},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			},
+		}
+
+		// Parse the policy.
+		pol, err := c.K8sNetworkPolicyToCalico(&np)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert key fields are correct.
+		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.test.policy"))
+
+		// Assert value fields are correct.
+		Expect(int(*pol.Value.(*apiv3.NetworkPolicy).Spec.Order)).To(Equal(1000))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal(""))
+
+		// There should be no Egress rules.
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))
+
+		// Check that Types field exists and has only 'ingress'
+		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Types)).To(Equal(1))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
+	})
+
 	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
 		np := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1034,6 +1080,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
+		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.NamespaceSelector).To(Equal("all()"))
 
 		// There should be no Egress rules.
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))
@@ -1696,51 +1743,6 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 		Expect(int(*pol.Value.(*apiv3.NetworkPolicy).Spec.Order)).To(Equal(1000))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(0))
-
-		// There should be no Egress rule.
-		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))
-
-		// Check that Types field exists and has only 'ingress'
-		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Types)).To(Equal(1))
-		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
-	})
-
-	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
-		np := networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test.policy",
-				Namespace: "default",
-			},
-			Spec: networkingv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{"label": "value"},
-				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{
-					{
-						From: []networkingv1.NetworkPolicyPeer{
-							{
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		// Parse the policy.
-		pol, err := c.K8sNetworkPolicyToCalico(&np)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Assert key fields are correct.
-		Expect(pol.Key.(model.ResourceKey).Name).To(Equal("knp.default.test.policy"))
-
-		// Assert value fields are correct.
-		Expect(int(*pol.Value.(*apiv3.NetworkPolicy).Spec.Order)).To(Equal(1000))
-		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s' && label == 'value'"))
-		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
-		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress[0].Source.Selector).To(Equal("projectcalico.org/orchestrator == 'k8s'"))
 
 		// There should be no Egress rule.
 		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(0))

--- a/lib/backend/k8s/k8s.go
+++ b/lib/backend/k8s/k8s.go
@@ -50,7 +50,7 @@ var (
 
 type KubeClient struct {
 	// Main Kubernetes clients.
-	clientSet *kubernetes.Clientset
+	ClientSet *kubernetes.Clientset
 
 	// Client for interacting with CustomResourceDefinition.
 	crdClientV1 *rest.RESTClient
@@ -117,7 +117,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 	if err != nil {
 		return nil, resources.K8sErrorToCalico(err, nil)
 	}
-	log.Debugf("Created k8s clientSet: %+v", cs)
+	log.Debugf("Created k8s ClientSet: %+v", cs)
 
 	crdClientV1, err := buildCRDClientV1(*config)
 	if err != nil {
@@ -125,7 +125,7 @@ func NewKubeClient(ca *apiconfig.CalicoAPIConfigSpec) (api.Client, error) {
 	}
 
 	kubeClient := &KubeClient{
-		clientSet:             cs,
+		ClientSet:             cs,
 		crdClientV1:           crdClientV1,
 		disableNodePoll:       ca.K8sDisableNodePoll,
 		clientsByResourceKind: make(map[string]resources.K8sResourceClient),
@@ -229,7 +229,7 @@ func (c *KubeClient) registerResourceClient(keyType, listType reflect.Type, reso
 }
 
 // getResourceClientFromKey returns the appropriate resource client for the v3 resource kind.
-func (c *KubeClient) getResourceClientFromResourceKind(kind string) resources.K8sResourceClient {
+func (c *KubeClient) GetResourceClientFromResourceKind(kind string) resources.K8sResourceClient {
 	return c.clientsByResourceKind[kind]
 }
 
@@ -493,7 +493,7 @@ func (c *KubeClient) listHostConfig(ctx context.Context, l model.HostConfigListO
 
 	// First see if we were handed a specific host, if not list all Nodes
 	if l.Hostname == "" {
-		nodes, err := c.clientSet.CoreV1().Nodes().List(metav1.ListOptions{})
+		nodes, err := c.ClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
 		if err != nil {
 			return nil, resources.K8sErrorToCalico(err, l)
 		}
@@ -507,7 +507,7 @@ func (c *KubeClient) listHostConfig(ctx context.Context, l model.HostConfigListO
 			kvps = append(kvps, kvp)
 		}
 	} else {
-		node, err := c.clientSet.CoreV1().Nodes().Get(l.Hostname, metav1.GetOptions{})
+		node, err := c.ClientSet.CoreV1().Nodes().Get(l.Hostname, metav1.GetOptions{})
 		if err != nil {
 			return nil, resources.K8sErrorToCalico(err, l)
 		}

--- a/lib/backend/k8s/k8s_suite_test.go
+++ b/lib/backend/k8s/k8s_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package k8s_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/lib/backend/k8s/k8s_test.go
+++ b/lib/backend/k8s/k8s_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 
 		// Clean up any k8s network policy left over by the test.
 		nps := networkingv1.NetworkPolicyList{}
-		err = c.clientSet.NetworkingV1().RESTClient().
+		err = c.ClientSet.NetworkingV1().RESTClient().
 			Get().
 			Resource("networkpolicies").
 			Timeout(10 * time.Second).
@@ -335,7 +335,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, np := range nps.Items {
-			result := c.clientSet.NetworkingV1().RESTClient().
+			result := c.ClientSet.NetworkingV1().RESTClient().
 				Delete().
 				Resource("networkpolicies").
 				Namespace(np.Namespace).
@@ -346,11 +346,11 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		}
 
 		// Clean up any pods left over by the test.
-		pods, err := c.clientSet.CoreV1().Pods("").List(metav1.ListOptions{})
+		pods, err := c.ClientSet.CoreV1().Pods("").List(metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, p := range pods.Items {
-			err = c.clientSet.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
+			err = c.ClientSet.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -367,7 +367,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		}
 
 		By("Creating a namespace", func() {
-			_, err := c.clientSet.CoreV1().Namespaces().Create(&ns)
+			_, err := c.ClientSet.CoreV1().Namespaces().Create(&ns)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -393,7 +393,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleting the namespace", func() {
-			err := c.clientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
+			err := c.ClientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -415,7 +415,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 
 		// Check to see if the create succeeded.
 		By("Creating a namespace", func() {
-			_, err := c.clientSet.CoreV1().Namespaces().Create(&ns)
+			_, err := c.ClientSet.CoreV1().Namespaces().Create(&ns)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -444,7 +444,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("deleting a namespace", func() {
-			err := c.clientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
+			err := c.ClientSet.CoreV1().Namespaces().Delete(ns.ObjectMeta.Name, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -482,7 +482,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				},
 			},
 		}
-		res := c.clientSet.NetworkingV1().RESTClient().
+		res := c.ClientSet.NetworkingV1().RESTClient().
 			Post().
 			Resource("networkpolicies").
 			Namespace("default").
@@ -508,7 +508,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 	It("should handle a CRUD of Global Network Policy", func() {
 		var kvpRes *model.KVPair
 
-		gnpClient := c.getResourceClientFromResourceKind(apiv3.KindGlobalNetworkPolicy)
+		gnpClient := c.GetResourceClientFromResourceKind(apiv3.KindGlobalNetworkPolicy)
 		kvp1Name := "my-test-gnp"
 		kvp1KeyV1 := model.PolicyKey{Name: kvp1Name}
 		kvp1a := &model.KVPair{
@@ -1199,7 +1199,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				},
 			},
 		}
-		_, err := c.clientSet.CoreV1().Pods("default").Create(&pod)
+		_, err := c.ClientSet.CoreV1().Pods("default").Create(&pod)
 		wepName := "127.0.0.1-k8s-test--syncer--basic--pod-eth0"
 
 		By("Creating a pod", func() {
@@ -1210,7 +1210,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			// Update the Pod to have an IP and be running.
 			pod.Status.PodIP = "192.168.1.1"
 			pod.Status.Phase = k8sapi.PodRunning
-			_, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(&pod)
+			_, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(&pod)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -1218,7 +1218,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			// Wait up to 120s for pod to start running.
 			log.Warnf("[TEST] Waiting for pod %s to start", pod.ObjectMeta.Name)
 			for i := 0; i < 120; i++ {
-				p, err := c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+				p, err := c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				if p.Status.Phase == k8sapi.PodRunning {
 					// Pod is running
@@ -1226,7 +1226,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				}
 				time.Sleep(1 * time.Second)
 			}
-			p, err := c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+			p, err := c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(p.Status.Phase).To(Equal(k8sapi.PodRunning))
 		})
@@ -1284,7 +1284,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleting the Pod and expecting the wep to be deleted", func() {
-			err = c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
+			err = c.ClientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			cb.ExpectDeleted([]model.KVPair{expectedKVP})
 		})
@@ -1310,7 +1310,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		}
 		// Note: assigning back to pod variable in order to pick up revision information. If we don't do that then
 		// the call to UpdateStatus() below would succeed, but it would overwrite our annotation patch.
-		pod, err := c.clientSet.CoreV1().Pods("default").Create(pod)
+		pod, err := c.ClientSet.CoreV1().Pods("default").Create(pod)
 		wepName := "127.0.0.1-k8s-test--syncer--basic--pod-eth0"
 
 		By("Creating a pod", func() {
@@ -1331,7 +1331,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get the pod through the k8s API to check the annotation has appeared.
-			p, err := c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+			p, err := c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(p.Annotations["cni.projectcalico.org/podIP"]).To(Equal("192.168.1.1"))
 
@@ -1345,14 +1345,14 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			// Try to update the pod using the old revision; this should fail because our patch made it
 			// stale.
 			pod.Status.Phase = k8sapi.PodRunning
-			_, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
+			_, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)
 			Expect(err).To(HaveOccurred())
 
 			// Re-get the pod and try again...
-			pod, err = c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+			pod, err = c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			pod.Status.Phase = k8sapi.PodRunning
-			pod, err = c.clientSet.CoreV1().Pods("default").UpdateStatus(pod)
+			pod, err = c.ClientSet.CoreV1().Pods("default").UpdateStatus(pod)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -1361,7 +1361,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 			log.Warnf("[TEST] Waiting for pod %s to start", pod.ObjectMeta.Name)
 
 			for i := 0; i < 120; i++ {
-				p, err := c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+				p, err := c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				if p.Status.Phase == k8sapi.PodRunning {
 					// Pod is running
@@ -1370,7 +1370,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 				time.Sleep(1 * time.Second)
 			}
 
-			pod, err = c.clientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
+			pod, err = c.ClientSet.CoreV1().Pods("default").Get(pod.ObjectMeta.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod.Status.Phase).To(Equal(k8sapi.PodRunning))
 			Expect(pod.Annotations["cni.projectcalico.org/podIP"]).To(Equal("192.168.1.1"))
@@ -1396,7 +1396,7 @@ var _ = Describe("Test Syncer API for Kubernetes backend", func() {
 		})
 
 		By("Deleting the Pod and expecting the wep to be deleted", func() {
-			err = c.clientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
+			err = c.ClientSet.CoreV1().Pods("default").Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			cb.ExpectDeleted([]model.KVPair{expectedKVP})
 		})

--- a/lib/backend/syncersv1/updateprocessors/rules.go
+++ b/lib/backend/syncersv1/updateprocessors/rules.go
@@ -52,6 +52,11 @@ func entityRuleAPIV2TOBackend(er *apiv3.EntityRule, ns string) (nsSelector, sele
 		// A namespace selector was given - the rule applies to all namespaces
 		// which match this selector.
 		nsSelector = parseSelectorAttachPrefix(er.NamespaceSelector, conversion.NamespaceLabelPrefix)
+
+		// We treat "all()" as "select all namespaces". Since in the v1 data model "all()" will select
+		// all endpoints, translate this to an equivalent expressions which means select any workload that
+		// is in a namespace.
+		nsSelector = strings.Replace(nsSelector, "all()", "has(projectcalico.org/namespace)", -1)
 	} else if ns != "" {
 		// No namespace selector was given and this is a namespaced network policy,
 		// so the rule applies only to its own namespace.

--- a/lib/validator/v1/validator.go
+++ b/lib/validator/v1/validator.go
@@ -42,7 +42,7 @@ var (
 	labelValueRegex     = regexp.MustCompile("^[a-zA-Z0-9]?([a-zA-Z0-9_.-]{0,61}[a-zA-Z0-9])?$")
 	nameRegex           = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,128}$")
 	namespacedNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_./-]{1,128}$`)
-	interfaceRegex      = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
+	interfaceRegex      = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
 	actionRegex         = regexp.MustCompile("^(allow|deny|log|pass)$")
 	backendActionRegex  = regexp.MustCompile("^(allow|deny|log|next-tier|)$")
 	protocolRegex       = regexp.MustCompile("^(tcp|udp|icmp|icmpv6|sctp|udplite)$")

--- a/lib/validator/v1/validator_test.go
+++ b/lib/validator/v1/validator_test.go
@@ -433,11 +433,10 @@ func init() {
 		Entry("should reject label value ending with ~", api.HostEndpointMetadata{Labels: map[string]string{"rank_.0-9": "gold~"}}, false),
 
 		// (API) Interface.
-		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "ValidIntface0-9"}, true),
+		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "Valid_Iface.0-9"}, true),
 		Entry("should reject an interface that is too long", api.WorkloadEndpointSpec{InterfaceName: "interfaceTooLong"}, false),
 		Entry("should reject & in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid&Intface"}, false),
 		Entry("should reject # in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid#Intface"}, false),
-		Entry("should reject . in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid.Intface"}, false),
 		Entry("should reject : in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid:Intface"}, false),
 
 		// (API) Scope

--- a/lib/validator/v3/validator.go
+++ b/lib/validator/v3/validator.go
@@ -62,7 +62,7 @@ var (
 	// GlobalNetworkPolicy names must be a simple DNS1123 label format (nameLabelFmt).
 	globalNetworkPolicyNameRegex = regexp.MustCompile("^(" + nameLabelFmt + ")$")
 
-	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_-]{1,15}$")
+	interfaceRegex        = regexp.MustCompile("^[a-zA-Z0-9_.-]{1,15}$")
 	actionRegex           = regexp.MustCompile("^(Allow|Deny|Log|Pass)$")
 	protocolRegex         = regexp.MustCompile("^(TCP|UDP|ICMP|ICMPv6|SCTP|UDPLite)$")
 	ipipModeRegex         = regexp.MustCompile("^(Always|CrossSubnet|Never)$")

--- a/lib/validator/v3/validator_test.go
+++ b/lib/validator/v3/validator_test.go
@@ -454,11 +454,10 @@ func init() {
 		),
 
 		// (API) Interface.
-		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "ValidIntface0-9"}, true),
+		Entry("should accept a valid interface", api.WorkloadEndpointSpec{InterfaceName: "Valid_Iface.0-9"}, true),
 		Entry("should reject an interface that is too long", api.WorkloadEndpointSpec{InterfaceName: "interfaceTooLong"}, false),
 		Entry("should reject & in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid&Intface"}, false),
 		Entry("should reject # in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid#Intface"}, false),
-		Entry("should reject . in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid.Intface"}, false),
 		Entry("should reject : in an interface", api.WorkloadEndpointSpec{InterfaceName: "Invalid:Intface"}, false),
 
 		// (API) FelixConfiguration.


### PR DESCRIPTION
We add a WarnMode annotation, which means that packets are always
allowed but we log when they would have been dropped.

We also add a LogNoRuleMatch annotation, which means you can log when
packets are dropped without setting WarnMode.